### PR TITLE
Add support for credits

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -16,7 +16,7 @@
     Source: <a id="source"></a>
     <br>
     Created with <a href="https://github.com/potomak/gist-txt">gist-txt</a>
-    by <a rel="author" href="http://twitter.com/johnnyaboh">Giovanni Cappellotto</a>
+    by <a rel="author">Anonymous</a>
     <br>
     <a href="text-adventures.html">More text adventures</a>
   </footer>

--- a/src/components.js
+++ b/src/components.js
@@ -14,9 +14,19 @@ function content() {
   return document.getElementById("content")
 }
 
+function sourceLink() {
+  return document.querySelector("a#source")
+}
+
+function creditsLink() {
+  return document.querySelector("a[rel='author']")
+}
+
 export default {
   error,
   loading,
   footer,
-  content
+  content,
+  sourceLink,
+  creditsLink
 }

--- a/src/index.js
+++ b/src/index.js
@@ -164,14 +164,42 @@ function loadAndRender(scene) {
 }
 
 //
-// If the gist response is successful the footer, that includes a link to the
-// original gist, is displayed.
+// If the gist response is successful the footer will be displayed.
+//
+// The footer includes these information:
+//
+// * a link to the original gist
+// * a link to the credits page
 //
 function compileAndDisplayFooter() {
-  const source = document.querySelector("a#source")
+  const source = components.sourceLink()
   source.setAttribute("href", `https://gist.github.com/${gistId}`)
   source.innerHTML = gistId
+
+  creditsLink()
+
   basic.show(components.footer())
+}
+
+//
+// The credits page contains information about the authors of the text
+// adventure.
+//
+// Data for the credits page is stored in a the conventional `credits.markdown`
+// file. If the `author` property is present in the file's data header it will
+// be used as the content of the link in the footer.
+//
+function creditsLink() {
+  getScene("credits")
+    .then(parsed => {
+      const credits = components.creditsLink()
+      credits.setAttribute("href", "credits")
+      credits.addEventListener("click", sceneLinkClickListener.bind(this, "credits"))
+      if (parsed.data.author !== undefined) {
+        credits.innerHTML = parsed.data.author
+      }
+    })
+    .catch(() => true)
 }
 
 //
@@ -308,13 +336,15 @@ function handleInternalLinks() {
       return
     }
 
-    anchor.addEventListener("click", event => {
-      event.preventDefault()
-      const hash = `#${gistId}/${href}`
-      runScene(hash)
-      window.history.pushState(null, null, document.location.pathname + hash)
-    })
+    anchor.addEventListener("click", sceneLinkClickListener.bind(this, href))
   })
+}
+
+function sceneLinkClickListener(scene, event) {
+  event.preventDefault()
+  const hash = `#${gistId}/${scene}`
+  runScene(hash)
+  window.history.pushState(null, null, document.location.pathname + hash)
 }
 
 function isExternal(href) {


### PR DESCRIPTION
Add a dynamic link in the footer to the credits page.

The credits page behaves like a scene and displays content from the
`credits.markdown` file.

The `author` property in the `credits.markdown` header data is used as
the content of the credits link in the footer.

See #1 